### PR TITLE
Fix box and edge colours of mermaid diagrams

### DIFF
--- a/themes/geekboot/assets/scss/_mermaid.scss
+++ b/themes/geekboot/assets/scss/_mermaid.scss
@@ -10,5 +10,14 @@
         stroke: var(--body-font-color) !important;
     }
 
-
+    .cluster {
+        &>rect {
+            fill: color-mix(in srgb,
+                color-mix(in srgb, var(--hint-note-background) 50%, #ffffff 50%) 80%,
+            transparent 100%) !important;
+        }
+        span {
+            color: var(--body-font-color) !important;
+        }
+    }
 }


### PR DESCRIPTION
- Make diagram edges prettier in dark mode
- Make diagram boxes slightly transparent for easier distinction between levels

![image](https://github.com/user-attachments/assets/dafe4993-799d-4a8c-a61b-4c62f095c066)
![image](https://github.com/user-attachments/assets/39b3cc62-f5d4-4a60-a092-8790a8838cf2)
 